### PR TITLE
Added code to store and reuse experiment parameters from json files.

### DIFF
--- a/experiments/cf-experiment.json
+++ b/experiments/cf-experiment.json
@@ -1,0 +1,11 @@
+{
+    "max_contests": 2000,
+    "mu_noob": 1500,
+    "sig_noob": 300,
+    "topk": 50,
+    "system": { 
+        "method": "codeforces", 
+        "params": [100.0, 1.7782794100389228] 
+    },
+    "contest_source": "codeforces"
+}

--- a/experiments/elor-experiment.json
+++ b/experiments/elor-experiment.json
@@ -1,0 +1,11 @@
+{
+    "max_contests": 2000,
+    "mu_noob": 1500,
+    "sig_noob": 300,
+    "topk": 50,
+    "system": { 
+        "method": "elor", 
+        "params": [100.0, 10.0, 1.0] 
+    },
+    "contest_source": "codeforces"
+}

--- a/experiments/tc-experiment.json
+++ b/experiments/tc-experiment.json
@@ -1,0 +1,11 @@
+{
+    "max_contests": 2000,
+    "mu_noob": 1500,
+    "sig_noob": 300,
+    "topk": 50,
+    "system": { 
+        "method": "topcoder", 
+        "params": [1.25892] 
+    },
+    "contest_source": "codeforces"
+}

--- a/experiments/ts-experiment.json
+++ b/experiments/ts-experiment.json
@@ -1,0 +1,11 @@
+{
+    "max_contests": 2000,
+    "mu_noob": 1500,
+    "sig_noob": 300,
+    "topk": 50,
+    "system": { 
+        "method": "trueskill", 
+        "params": [0.4, 140.0, 0.0002, 20.0] 
+    },
+    "contest_source": "codeforces"
+}

--- a/ranking/Cargo.toml
+++ b/ranking/Cargo.toml
@@ -21,3 +21,6 @@ name = "run"
 
 [[bin]]
 name = "report"
+
+[[bin]]
+name = "results"

--- a/ranking/src/bin/results.rs
+++ b/ranking/src/bin/results.rs
@@ -1,0 +1,59 @@
+extern crate ranking;
+
+use ranking::compute_ratings::{get_participant_ratings, simulate_contest};
+use ranking::contest_config::{get_contest, get_contest_config, get_contest_ids};
+use ranking::experiment_config::{load_experiment};
+use ranking::metrics::{compute_metrics_custom, PerformanceReport};
+use std::collections::HashMap;
+use std::time::Instant;
+
+#[allow(unused_imports)]
+use ranking::{CodeforcesSystem, EloRSystem, TopCoderSystem, TrueSkillSPBSystem};
+
+fn main() {
+    // Load system configs from parameter files
+    let experiment_files = vec![
+        "../experiments/cf-experiment.json".to_string(),
+        "../experiments/tc-experiment.json".into(),
+        "../experiments/elor-experiment.json".into(),
+        "../experiments/ts-experiment.json".into()
+    ];
+
+    for filename in experiment_files.iter() {
+        let experiment = load_experiment(&filename);
+        
+        let config = get_contest_config(experiment.contest_source);
+        let contest_ids = get_contest_ids(&config.contest_id_file);
+        
+        let system = experiment.system;
+        
+        let max_contests = experiment.max_contests;
+        let mu_noob = experiment.mu_noob;
+        let sig_noob = experiment.sig_noob;
+        let topk = experiment.topk;
+
+        let mut players = HashMap::new();
+        let mut avg_perf = PerformanceReport::new(3);
+        let now = Instant::now();
+
+        // Run the contest histories and measure
+        for &contest_id in contest_ids.iter().take(max_contests) {
+            let contest = get_contest(&config.contest_cache_folder, contest_id);
+
+            // Predict performance must be run before simulate contest
+            // since we don't want to make predictions after we've seen the contest
+            let standings = get_participant_ratings(&mut players, &contest, 0);
+            avg_perf += compute_metrics_custom(&standings, topk);
+
+            // Now run the actual rating update
+            simulate_contest(&mut players, &contest, &*system, mu_noob, sig_noob);
+        }
+        println!(
+            "{:?}: {}, {}s",
+            system,
+            avg_perf,
+            now.elapsed().as_millis() as f64 / 1000.
+        );
+        println!("=============================================================");
+    }
+}

--- a/ranking/src/bin/results.rs
+++ b/ranking/src/bin/results.rs
@@ -2,7 +2,7 @@ extern crate ranking;
 
 use ranking::compute_ratings::{get_participant_ratings, simulate_contest};
 use ranking::contest_config::{get_contest, get_contest_config, get_contest_ids};
-use ranking::experiment_config::{load_experiment};
+use ranking::experiment_config::load_experiment;
 use ranking::metrics::{compute_metrics_custom, PerformanceReport};
 use std::collections::HashMap;
 use std::time::Instant;
@@ -16,17 +16,17 @@ fn main() {
         "../experiments/cf-experiment.json".to_string(),
         "../experiments/tc-experiment.json".into(),
         "../experiments/elor-experiment.json".into(),
-        "../experiments/ts-experiment.json".into()
+        "../experiments/ts-experiment.json".into(),
     ];
 
     for filename in experiment_files.iter() {
         let experiment = load_experiment(&filename);
-        
+
         let config = get_contest_config(experiment.contest_source);
         let contest_ids = get_contest_ids(&config.contest_id_file);
-        
+
         let system = experiment.system;
-        
+
         let max_contests = experiment.max_contests;
         let mu_noob = experiment.mu_noob;
         let sig_noob = experiment.sig_noob;

--- a/ranking/src/contest_config.rs
+++ b/ranking/src/contest_config.rs
@@ -17,6 +17,7 @@ pub enum ContestSource {
     Reddit,
     StackOverflow,
     Synthetic,
+    NotFound,
 }
 
 pub struct ContestConfig {
@@ -30,6 +31,7 @@ pub fn get_contest_config(source: ContestSource) -> ContestConfig {
         ContestSource::Reddit => "reddit",
         ContestSource::StackOverflow => "stackoverflow",
         ContestSource::Synthetic => "synthetic",
+        ContestSource::NotFound => "not-found",
     };
 
     ContestConfig {

--- a/ranking/src/experiment_config.rs
+++ b/ranking/src/experiment_config.rs
@@ -1,0 +1,77 @@
+use crate::contest_config::ContestSource;
+use crate::compute_ratings::RatingSystem;
+
+#[allow(unused_imports)]
+use crate::{CodeforcesSystem, EloRSystem, TopCoderSystem, TrueSkillSPBSystem};
+
+use serde::{Deserialize};
+use std::path::Path;
+
+#[derive(Deserialize, Debug)]
+pub struct SystemParams {
+    pub method: String,
+    pub params: Vec<f64>,
+}
+
+#[derive(Deserialize, Debug)]
+pub struct ExperimentFile {
+    pub max_contests: usize,
+    pub mu_noob: f64,
+    pub sig_noob: f64,
+    pub topk: usize,
+    pub system: SystemParams,
+    pub contest_source: String,
+}
+
+pub struct Experiment {
+    pub max_contests: usize,
+    pub mu_noob: f64,
+    pub sig_noob: f64,
+    pub topk: usize,
+    pub system: Box<dyn RatingSystem>,
+    pub contest_source: ContestSource,
+}
+
+pub fn load_experiment<P: AsRef<Path>>(source: &P) -> Experiment {
+    let params_json =
+        std::fs::read_to_string(source).expect("Failed to read parameters file");
+    let params: ExperimentFile = serde_json::from_str(&params_json).expect("Failed to parse parameters as JSON");
+
+    println!("Loading rating system:\n{:#?}", params);
+    let source = match &params.contest_source[..] {
+        "codeforces" => ContestSource::Codeforces,
+        "reddit" => ContestSource::Reddit,
+        "stackoverflow" => ContestSource::StackOverflow,
+        "synthetic" => ContestSource::Synthetic,
+        _ => ContestSource::NotFound,
+    };
+
+    let system: Box<dyn RatingSystem> = match &params.system.method[..] {
+        "codeforces" => Box::new(CodeforcesSystem { 
+            sig_perf: params.system.params[0], 
+            weight: params.system.params[1] }),
+        "topcoder" => Box::new(TopCoderSystem {
+            weight_multiplier: params.system.params[0] }),
+        "elor" => Box::new(EloRSystem {
+            sig_perf: params.system.params[0],
+            sig_drift: params.system.params[1],
+            variant: crate::elor_system::EloRVariant::Logistic(params.system.params[2]),
+            split_ties: false }),
+        "trueskill" => Box::new(TrueSkillSPBSystem {
+            eps: params.system.params[0],
+            beta: params.system.params[1],
+            convergence_eps: params.system.params[2],
+            sigma_growth: params.system.params[3] }),
+        _ => Box::new(EloRSystem::default()),
+    };
+
+    // format!("../data/{}/contest_ids.json", source_name)
+    Experiment {
+        max_contests: params.max_contests,
+        mu_noob: params.mu_noob,
+        sig_noob: params.sig_noob,
+        topk: params.topk,
+        system: system,
+        contest_source: source,
+    }
+}

--- a/ranking/src/experiment_config.rs
+++ b/ranking/src/experiment_config.rs
@@ -1,10 +1,10 @@
-use crate::contest_config::ContestSource;
 use crate::compute_ratings::RatingSystem;
+use crate::contest_config::ContestSource;
 
 #[allow(unused_imports)]
 use crate::{CodeforcesSystem, EloRSystem, TopCoderSystem, TrueSkillSPBSystem};
 
-use serde::{Deserialize};
+use serde::Deserialize;
 use std::path::Path;
 
 #[derive(Deserialize, Debug)]
@@ -14,7 +14,7 @@ pub struct SystemParams {
 }
 
 #[derive(Deserialize, Debug)]
-pub struct ExperimentFile {
+pub struct ExperimentConfig {
     pub max_contests: usize,
     pub mu_noob: f64,
     pub sig_noob: f64,
@@ -33,9 +33,9 @@ pub struct Experiment {
 }
 
 pub fn load_experiment<P: AsRef<Path>>(source: &P) -> Experiment {
-    let params_json =
-        std::fs::read_to_string(source).expect("Failed to read parameters file");
-    let params: ExperimentFile = serde_json::from_str(&params_json).expect("Failed to parse parameters as JSON");
+    let params_json = std::fs::read_to_string(source).expect("Failed to read parameters file");
+    let params: ExperimentConfig =
+        serde_json::from_str(&params_json).expect("Failed to parse parameters as JSON");
 
     println!("Loading rating system:\n{:#?}", params);
     let source = match &params.contest_source[..] {
@@ -46,32 +46,35 @@ pub fn load_experiment<P: AsRef<Path>>(source: &P) -> Experiment {
         _ => ContestSource::NotFound,
     };
 
-    let system: Box<dyn RatingSystem> = match &params.system.method[..] {
-        "codeforces" => Box::new(CodeforcesSystem { 
-            sig_perf: params.system.params[0], 
-            weight: params.system.params[1] }),
+    let rating_system: Box<dyn RatingSystem> = match &params.system.method[..] {
+        "codeforces" => Box::new(CodeforcesSystem {
+            sig_perf: params.system.params[0],
+            weight: params.system.params[1],
+        }),
         "topcoder" => Box::new(TopCoderSystem {
-            weight_multiplier: params.system.params[0] }),
+            weight_multiplier: params.system.params[0],
+        }),
         "elor" => Box::new(EloRSystem {
             sig_perf: params.system.params[0],
             sig_drift: params.system.params[1],
             variant: crate::elor_system::EloRVariant::Logistic(params.system.params[2]),
-            split_ties: false }),
+            split_ties: false,
+        }),
         "trueskill" => Box::new(TrueSkillSPBSystem {
             eps: params.system.params[0],
             beta: params.system.params[1],
             convergence_eps: params.system.params[2],
-            sigma_growth: params.system.params[3] }),
+            sigma_growth: params.system.params[3],
+        }),
         _ => Box::new(EloRSystem::default()),
     };
 
-    // format!("../data/{}/contest_ids.json", source_name)
     Experiment {
         max_contests: params.max_contests,
         mu_noob: params.mu_noob,
         sig_noob: params.sig_noob,
         topk: params.topk,
-        system: system,
+        system: rating_system,
         contest_source: source,
     }
 }

--- a/ranking/src/lib.rs
+++ b/ranking/src/lib.rs
@@ -3,6 +3,7 @@ pub mod contest_config;
 pub mod metrics;
 pub mod read_codeforces;
 pub mod summary;
+pub mod experiment_config;
 
 pub mod cf_system;
 pub mod elor_system;

--- a/ranking/src/lib.rs
+++ b/ranking/src/lib.rs
@@ -1,9 +1,9 @@
 pub mod compute_ratings;
 pub mod contest_config;
+pub mod experiment_config;
 pub mod metrics;
 pub mod read_codeforces;
 pub mod summary;
-pub mod experiment_config;
 
 pub mod cf_system;
 pub mod elor_system;


### PR DESCRIPTION
See `./ranking/src/bin/results.rs`, `./ranking/src/experiment_config.rs`, and the json files in `./experiments` for examples of how to use.