### PR TITLE
Store display_rating in PlayerEvent

### DIFF
--- a/multi-skill/src/bin/summary_to_checkpoint.rs
+++ b/multi-skill/src/bin/summary_to_checkpoint.rs
@@ -41,6 +41,7 @@ fn make_checkpoint(players: Vec<SimplePlayer>) -> PlayersByName {
                 rating_sig: 0,
                 perf_score: 0,
                 place: 0,
+                display_rating: 0,
             };
             player.event_history.push(fake_event);
             player.update_rating(player.approx_posterior, simp.cur_mu);

--- a/multi-skill/src/bin/update_player.rs
+++ b/multi-skill/src/bin/update_player.rs
@@ -37,6 +37,7 @@ fn main() {
         rating_sig: 0,    // will be filled by system.individual_update()
         perf_score: 0,    // will be filled by system.individual_update()
         place: 0,         // this information is not available
+        display_rating: 0, // will be filled by system.individual_update()
     });
 
     // Perform the rating update with the configured parameters

--- a/multi-skill/src/summary.rs
+++ b/multi-skill/src/summary.rs
@@ -53,14 +53,14 @@ pub fn make_leaderboard(
         let max_rating = player
             .event_history
             .iter()
-            .map(PlayerEvent::get_display_rating)
+            .map(|event| event.display_rating)
             .max()
             .unwrap();
-        let display_rating = last_event.get_display_rating();
+        let display_rating = last_event.display_rating;
         let prev_rating = if num_contests == 1 {
             0
         } else {
-            player.event_history[num_contests - 2].get_display_rating()
+            player.event_history[num_contests - 2].display_rating
         };
         rating_data.push(PlayerSummary {
             rank: None,

--- a/multi-skill/src/systems/common/mod.rs
+++ b/multi-skill/src/systems/common/mod.rs
@@ -166,6 +166,7 @@ pub fn simulate_contest(
                 rating_sig: 0, // will be filled by system.round_update()
                 perf_score: 0, // will be filled by system.round_update()
                 place: lo,
+                display_rating: 0, // will be filled by system.individual_update()
             });
             player.delta_time = contest.time_seconds - player.update_time;
             player.update_time = contest.time_seconds;

--- a/multi-skill/src/systems/common/player.rs
+++ b/multi-skill/src/systems/common/player.rs
@@ -9,6 +9,7 @@ pub struct PlayerEvent {
     pub rating_sig: i32,
     pub perf_score: i32,
     pub place: usize,
+    pub display_rating: i32,
 }
 
 impl PlayerEvent {
@@ -65,6 +66,8 @@ impl Player {
         last_event.rating_mu = rating.mu.round() as i32;
         last_event.rating_sig = rating.sig.round() as i32;
         last_event.perf_score = performance_score.round() as i32;
+
+        last_event.display_rating = last_event.get_display_rating();
     }
 
     pub fn update_rating_with_normal(&mut self, performance: Rating) {

--- a/worldrank-api/src/domain/history.rs
+++ b/worldrank-api/src/domain/history.rs
@@ -15,7 +15,7 @@ pub struct HistoryPoint {
 impl HistoryPoint {
     pub fn new(event: &PlayerEvent, contest: &ContestSummary) -> Self {
         Self {
-            display_rating: event.get_display_rating(),
+            display_rating: event.display_rating,
             perf_score: event.perf_score,
             place: event.place,
             num_contestants: contest.num_contestants,


### PR DESCRIPTION
Store the `display_rating` in the `PlayerEvent`s, so that it will be serialized in the CSV files.

Resulting CSV:
```
contest_index,rating_mu,rating_sig,perf_score,place,display_rating
0,1149,171,1081,56,876
1,1292,130,1423,71,1142
2,1449,111,1786,58,1356

```